### PR TITLE
cleanup and fixes

### DIFF
--- a/todo_mern_client/src/modals/formModal/components/Modal/TaskModal.tsx
+++ b/todo_mern_client/src/modals/formModal/components/Modal/TaskModal.tsx
@@ -90,9 +90,8 @@ export default function TaskModal({
 
   // Set the category as the newly created category if the user chooses to do that.
   useEffect(() => {
-    if (newCategoryId) {
-      setValue("categoryId", newCategoryId);
-    }
+    if (!newCategoryId) return;
+    setValue("categoryId", newCategoryId);
   }, [newCategoryId, setValue]);
 
   // set the default categoryValue to be "personal" when creating a new task

--- a/todo_mern_client/src/modals/formModal/components/Modal/TaskModal.tsx
+++ b/todo_mern_client/src/modals/formModal/components/Modal/TaskModal.tsx
@@ -5,6 +5,7 @@ import {
   DeleteButton,
   NewCategoryForm,
   DeleteConfirmModal,
+  CompletionCheckbox,
 } from "./components/index";
 import { DataContext } from "../../../../context/DataContext";
 import {
@@ -190,7 +191,8 @@ export default function TaskModal({
           </select>
         </div>
 
-        {getCompletionCheckbox(modalType, register)}
+        <CompletionCheckbox modalType={modalType} register={register} s={s} />
+
         <div className={s.form__buttonsWrapper}>
           <DeleteButton
             modalType={modalType}
@@ -227,28 +229,6 @@ export default function TaskModal({
           className={s.hideBackgroundWhenNewCategoryIsOpen}
         ></div>
       ) : null}
-    </div>
-  );
-}
-
-// utils function returning JSX,  might need to put this into a seperate compoent..
-function getCompletionCheckbox(
-  modalType: string,
-  register: UseFormRegister<DataFormInputTypes>,
-) {
-  if (modalType !== "configure") return;
-
-  return (
-    <div className={s.form__completionCheckboxInputWrapper}>
-      <label className={s.form__label} htmlFor="complete">
-        mark as complete:
-      </label>
-      <input
-        className={s.form__completionCheckboxInputWrapper__checkboxInput}
-        id={"complete"}
-        type="checkbox"
-        {...register("priority")}
-      />
     </div>
   );
 }

--- a/todo_mern_client/src/modals/formModal/components/Modal/components/CompletionCheckbox/CompletionCheckbox.tsx
+++ b/todo_mern_client/src/modals/formModal/components/Modal/components/CompletionCheckbox/CompletionCheckbox.tsx
@@ -1,0 +1,30 @@
+import { UseFormRegister } from "react-hook-form";
+import { DataFormInputTypes } from "../../../../../../types";
+
+interface CompletionCheckboxProps {
+  modalType: string;
+  register: UseFormRegister<DataFormInputTypes>;
+  s: CSSModuleClasses;
+}
+
+export default function CompletionCheckbox({
+  modalType,
+  register,
+  s,
+}: CompletionCheckboxProps) {
+  if (modalType !== "configure") return;
+
+  return (
+    <div className={s.form__completionCheckboxInputWrapper}>
+      <label className={s.form__label} htmlFor="complete">
+        mark as complete:
+      </label>
+      <input
+        className={s.form__completionCheckboxInputWrapper__checkboxInput}
+        id={"complete"}
+        type="checkbox"
+        {...register("priority")}
+      />
+    </div>
+  );
+}

--- a/todo_mern_client/src/modals/formModal/components/Modal/components/index.ts
+++ b/todo_mern_client/src/modals/formModal/components/Modal/components/index.ts
@@ -1,3 +1,4 @@
 export { default as DeleteButton } from "./DeleteButton/DeleteButton";
 export { default as NewCategoryForm } from "./NewCategoryForm/NewCategoryForm";
 export { default as DeleteConfirmModal } from "./DeleteConfirmModal/DeleteConfirmModal";
+export { default as CompletionCheckbox } from "./CompletionCheckbox/CompletionCheckbox";


### PR DESCRIPTION
- **the complete input is seperated into its own component**
- **in the useeffect where the new category is set - is returned of nothing**
